### PR TITLE
Improves client server communication

### DIFF
--- a/src/main/java/edu/stanford/bmir/protege/web/client/rpc/OntologyService.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/client/rpc/OntologyService.java
@@ -99,7 +99,4 @@ public interface OntologyService extends RemoteService {
                                         EntityData oldValueEntityData,
                                         String user, String operationDescription);
 
-
-    String convertOntologyForVowlVisualization(String projectName);
-
 }

--- a/src/main/java/edu/stanford/bmir/protege/web/client/rpc/OntologyServiceManager.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/client/rpc/OntologyServiceManager.java
@@ -162,10 +162,4 @@ public class OntologyServiceManager {
         proxy.replaceExternalReference(projectId.getId(), entityName, bpRefData, oldValueEntityData, userId.getUserName(), operationDescription, cb);
     }
 
-
-    public void convertForVowlVisualization(ProjectId projectId, AsyncCallback<String> cb) {
-        proxy.convertOntologyForVowlVisualization(projectId.getId(), cb);
-    }
-
-
 }

--- a/src/main/java/edu/stanford/bmir/protege/web/client/ui/visualization/vowl/VOWLVisualizationPortlet.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/client/ui/visualization/vowl/VOWLVisualizationPortlet.java
@@ -2,19 +2,21 @@ package edu.stanford.bmir.protege.web.client.ui.visualization.vowl;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
 import com.gwtext.client.widgets.Panel;
 import com.gwtext.client.widgets.TabPanel;
 import com.gwtext.client.widgets.form.Label;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceCallback;
+import edu.stanford.bmir.protege.web.client.dispatch.DispatchServiceManager;
 import edu.stanford.bmir.protege.web.client.project.Project;
-import edu.stanford.bmir.protege.web.client.rpc.OntologyServiceManager;
 import edu.stanford.bmir.protege.web.client.ui.portlet.AbstractOWLEntityPortlet;
 import edu.stanford.bmir.protege.web.shared.selection.SelectionModel;
+import edu.stanford.bmir.protege.web.shared.visualization.vowl.*;
 
 
+@SuppressWarnings("unchecked")
 public class VOWLVisualizationPortlet extends AbstractOWLEntityPortlet {
 
 	private static final String VOWL_TITLE = "WebVOWL 0.4.0";
@@ -24,24 +26,24 @@ public class VOWLVisualizationPortlet extends AbstractOWLEntityPortlet {
 		super(selectionModel, project);
 	}
 
-	@Override public void initialize() {
+	@Override 
+	public void initialize() {
 		setTitle(VOWL_TITLE);
 		Widget graphContainer = new HTML();
 		graphContainer.getElement().setId(getContainerId());
 		add(graphContainer);
-
-		OntologyServiceManager.getInstance()
-				.convertForVowlVisualization(getProjectId(), new AsyncCallback<String>() {
-					@Override
-					public void onFailure(Throwable caught) {
-						// TODO
-					}
-
-					@Override
-					public void onSuccess(String convertedOntology) {
-						initializeVisualizationWhenElementExists(convertedOntology);
-					}
-				});
+		
+		initializeView();
+	}
+	
+	public void initializeView() {
+		DispatchServiceManager.get().execute(new ConvertOntologyAction(getProjectId()), new DispatchServiceCallback<ConvertOntologyResult>() {
+			@Override
+			public void handleSuccess(ConvertOntologyResult result) {
+				String ontologyAsJSONStr = result.getOntologyasJSONStr();
+				initializeVisualizationWhenElementExists(ontologyAsJSONStr);
+			}
+		});
 	}
 
 	/**
@@ -65,18 +67,16 @@ public class VOWLVisualizationPortlet extends AbstractOWLEntityPortlet {
 
 	@Override
 	protected void onRefresh() {
-		OntologyServiceManager.getInstance()
-				.convertForVowlVisualization(getProjectId(), new AsyncCallback<String>() {
-					@Override
-					public void onFailure(Throwable caught) {
-						// TODO
-					}
-
-					@Override
-					public void onSuccess(String convertedOntology) {
-						visualizationJso.setData(convertedOntology);
-					}
-				});
+		
+		
+		DispatchServiceManager.get().execute(new ConvertOntologyAction(getProjectId()), new DispatchServiceCallback<ConvertOntologyResult>() {
+			@Override
+			public void handleSuccess(ConvertOntologyResult result) {
+				String ontologyAsJSONStr = result.getOntologyasJSONStr();
+				visualizationJso.setData(ontologyAsJSONStr);
+			}
+		});
+		
 	}
 
 	private String getContainerId() {

--- a/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/ActionHandlersModule.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/server/dispatch/ActionHandlersModule.java
@@ -2,6 +2,7 @@ package edu.stanford.bmir.protege.web.server.dispatch;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
+
 import edu.stanford.bmir.protege.web.server.app.GetClientApplicationPropertiesActionHandler;
 import edu.stanford.bmir.protege.web.server.auth.ChangePasswordActionHandler;
 import edu.stanford.bmir.protege.web.server.auth.GetChapSessionActionHandler;
@@ -46,6 +47,7 @@ import edu.stanford.bmir.protege.web.server.usage.GetUsageActionHandler;
 import edu.stanford.bmir.protege.web.server.user.CreateUserAccountActionHandler;
 import edu.stanford.bmir.protege.web.server.user.GetUserIdsActionHandler;
 import edu.stanford.bmir.protege.web.server.user.LogOutUserActionHandler;
+import edu.stanford.bmir.protege.web.server.visualization.vowl.ConvertOntologyHandler;
 import edu.stanford.bmir.protege.web.server.watches.AddWatchActionHandler;
 import edu.stanford.bmir.protege.web.server.watches.RemoveWatchActionHandler;
 import edu.stanford.bmir.protege.web.server.project.SetUIConfigurationActionHandler;
@@ -176,5 +178,7 @@ public class ActionHandlersModule extends AbstractModule {
         multibinder.addBinding().to(GetPersonIdCompletionsActionHandler.class);
         multibinder.addBinding().to(GetUserIdCompletionsActionHandler.class);
         multibinder.addBinding().to(GetPersonIdItemsActionHandler.class);
+        
+        multibinder.addBinding().to(ConvertOntologyHandler.class);
     }
 }

--- a/src/main/java/edu/stanford/bmir/protege/web/server/owlapi/OntologyServiceOWLAPIImpl.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/server/owlapi/OntologyServiceOWLAPIImpl.java
@@ -1,6 +1,5 @@
 package edu.stanford.bmir.protege.web.server.owlapi;
 
-import de.uni_stuttgart.vis.vowl.owl2vowl.Owl2Vowl;
 import edu.stanford.bmir.protege.web.client.rpc.OntologyService;
 import edu.stanford.bmir.protege.web.client.rpc.data.*;
 import edu.stanford.bmir.protege.web.server.PaginationServerUtil;
@@ -792,19 +791,5 @@ public class OntologyServiceOWLAPIImpl extends WebProtegeRemoteServiceServlet im
             firstSep = false;
         }
         return res;
-    }
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-    @Override
-    public String convertOntologyForVowlVisualization(String projectName) {
-        OWLOntology ontology = getOntology(projectName);
-        String ontologyURI = getOntologyURI(projectName);
-        Owl2Vowl owl2Vowl = new Owl2Vowl(ontology, ontologyURI);
-
-        return owl2Vowl.getJsonAsString();
     }
 }

--- a/src/main/java/edu/stanford/bmir/protege/web/server/visualization/vowl/ConvertOntologyHandler.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/server/visualization/vowl/ConvertOntologyHandler.java
@@ -1,0 +1,64 @@
+package edu.stanford.bmir.protege.web.server.visualization.vowl;
+
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyID;
+import com.google.inject.Inject;
+import de.uni_stuttgart.vis.vowl.owl2vowl.Owl2Vowl;
+import edu.stanford.bmir.protege.web.server.dispatch.ActionHandler;
+import edu.stanford.bmir.protege.web.server.dispatch.ExecutionContext;
+import edu.stanford.bmir.protege.web.server.dispatch.RequestContext;
+import edu.stanford.bmir.protege.web.server.dispatch.RequestValidator;
+import edu.stanford.bmir.protege.web.server.dispatch.validators.NullValidator;
+import edu.stanford.bmir.protege.web.server.owlapi.*;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+import edu.stanford.bmir.protege.web.shared.visualization.vowl.*;
+
+public class ConvertOntologyHandler implements ActionHandler<ConvertOntologyAction, ConvertOntologyResult> {
+
+	private OWLAPIProjectManager projectManager;
+
+	@Inject
+	public ConvertOntologyHandler(OWLAPIProjectManager projectManager) {
+		this.projectManager = projectManager;
+	}
+
+	@Override
+	public Class<ConvertOntologyAction> getActionClass() {
+		return ConvertOntologyAction.class;
+	}
+
+	@Override
+	public RequestValidator<ConvertOntologyAction> getRequestValidator(
+			ConvertOntologyAction action, RequestContext requestContext) {
+		return NullValidator.get();
+	}
+
+	@Override
+	public ConvertOntologyResult execute(ConvertOntologyAction action, 
+			ExecutionContext executionContext) {
+		ProjectId projectId = action.getProjectID();
+		String ontologyAsJSONStr = convertOntologyForVowlVisualization(projectId);
+
+		return new ConvertOntologyResult(ontologyAsJSONStr);
+	}
+
+	private String convertOntologyForVowlVisualization(ProjectId projectId) {
+		
+		OWLOntology ontology = projectManager.getProject(projectId).getRootOntology();
+		OWLOntologyID id = ontology.getOntologyID();
+
+		Owl2Vowl owl2Vowl = new Owl2Vowl(ontology, toName(id));
+
+		return owl2Vowl.getJsonAsString();
+	}
+
+	private String toName(OWLOntologyID id) {
+		if (id.isAnonymous()) {
+			return id.toString();
+		}
+		else {
+			return id.getOntologyIRI().toString();
+		}
+	}
+
+}

--- a/src/main/java/edu/stanford/bmir/protege/web/shared/visualization/vowl/ConvertOntologyAction.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/shared/visualization/vowl/ConvertOntologyAction.java
@@ -1,0 +1,22 @@
+package edu.stanford.bmir.protege.web.shared.visualization.vowl;
+
+import edu.stanford.bmir.protege.web.shared.dispatch.Action;
+import edu.stanford.bmir.protege.web.shared.project.ProjectId;
+
+public class ConvertOntologyAction implements Action<ConvertOntologyResult> {
+
+	private ProjectId projectId;
+	
+	ConvertOntologyAction() {
+
+	}
+	
+	public ConvertOntologyAction(ProjectId projectId) {
+		this.projectId = projectId;
+	}
+	
+	public ProjectId getProjectID() {
+		return projectId;
+	}
+	
+}

--- a/src/main/java/edu/stanford/bmir/protege/web/shared/visualization/vowl/ConvertOntologyResult.java
+++ b/src/main/java/edu/stanford/bmir/protege/web/shared/visualization/vowl/ConvertOntologyResult.java
@@ -1,0 +1,20 @@
+package edu.stanford.bmir.protege.web.shared.visualization.vowl;
+
+import edu.stanford.bmir.protege.web.shared.dispatch.Result;
+
+public class ConvertOntologyResult implements Result {
+
+	private String ontologyAsJSONStr;
+	
+	ConvertOntologyResult() {
+		
+	}
+	
+	public ConvertOntologyResult(String ontologyAsJSONStr) {
+		this.ontologyAsJSONStr = ontologyAsJSONStr;
+	}
+	
+	public String getOntologyasJSONStr() {
+		return ontologyAsJSONStr;
+	}
+}


### PR DESCRIPTION
- Removed visualization code snippets from original files (web/client/rpc/OntologyService, OntologyServiceManager and web/server/owlapi/OntologyServiceOWLAPIImpl).
- Created a ConvertOntologyAction (to get a projectId) and ConvertOntologyResult (to return an ontology as JSON string).
- Used a ConvertOntologyHandler to process the ConvertOntologyAction and ConvertOntologyResult.
- Registered the ConvertOntologyHandler to web/server/dispatch/ActionHandlersModule.
- Updated the VOWLVisualizationPortlet to reflect the aforementioned changes and particularly used the DispatchServiceManager to submit a ConvertOntologyAction to the server and receive a ConvertOntologyResult.
